### PR TITLE
Complete implementation of the feature: sharing

### DIFF
--- a/src/app/http/controllers/GlueBoardController.ts
+++ b/src/app/http/controllers/GlueBoardController.ts
@@ -13,6 +13,7 @@ interface IndexResponseBody {
       name: string
       color: string
     }
+    sharing: boolean
   }>
 }
 
@@ -22,6 +23,7 @@ interface GetResponseBody {
     name: string
     color: string
   }
+  sharing: boolean
 }
 
 export default class GlueBoardController {
@@ -51,7 +53,8 @@ export default class GlueBoardController {
       for (const glueBoard of glueBoards) {
         responseBody.glueBoards.push({
           id: glueBoard.id,
-          category: glueBoard.category
+          category: glueBoard.category,
+          sharing: glueBoard.sharing
         })
       }
 
@@ -143,7 +146,8 @@ export default class GlueBoardController {
         category: {
           name: glueBoard.category.name,
           color: glueBoard.category.color
-        }
+        },
+        sharing: glueBoard.sharing
       }
 
       return res.status(200).json(responseBody)

--- a/src/app/http/controllers/GlueBoardController.ts
+++ b/src/app/http/controllers/GlueBoardController.ts
@@ -202,6 +202,12 @@ export default class GlueBoardController {
         },
         errorMessage: '`color` must be a hex color.'
       },
+      sharing: {
+        optional: true,
+        in: 'body',
+        isBoolean: true,
+        errorMessage: '`sharing` must be a boolean.'
+      },
       position: {
         optional: true,
         in: 'body',
@@ -239,6 +245,11 @@ export default class GlueBoardController {
       // update category color
       if (req.body.color) {
         glueBoard.category.color = req.body.color
+      }
+
+      // update sharing option
+      if (req.body.sharing !== undefined) {
+        glueBoard.sharing = req.body.sharing
       }
 
       await glueBoard.save()

--- a/src/app/http/controllers/SharingController.ts
+++ b/src/app/http/controllers/SharingController.ts
@@ -10,13 +10,16 @@ export default class SharingController {
    * Get the url hash of shared GlueBoard
    */
   public static get(): SimpleHandler {
-    return async (req, res): Promise<Response> => {
+    return (req, res): Response => {
       const glueBoard = res.locals.glueBoard as GlueBoardDoc
 
-      // if sharing option is off, turn on.
+      // if sharing option is off, reject this request.
       if (glueBoard.sharing === false) {
-        glueBoard.sharing = true
-        await glueBoard.save()
+        return res.status(403).json({
+          err: {
+            msg: 'Sharing option for this GlueBoard is off.'
+          }
+        })
       }
 
       const responseBody: GetResponseBody = {

--- a/src/app/http/controllers/SharingController.ts
+++ b/src/app/http/controllers/SharingController.ts
@@ -23,7 +23,7 @@ interface GetResponseBody {
 
 export default class SharingController {
   /**
-   * Get the url hash of shared GlueBoard
+   * Get the url hash of the shared GlueBoard
    */
   public static getHash(): SimpleHandler {
     return (req, res): Response => {

--- a/src/app/http/controllers/SharingController.ts
+++ b/src/app/http/controllers/SharingController.ts
@@ -1,0 +1,29 @@
+import { Response, SimpleHandler } from '@/http/RequestHandler'
+import { GlueBoardDoc } from '@@/migrate/schemas/glue-board'
+
+interface GetResponseBody {
+  hash: string
+}
+
+export default class SharingController {
+  /**
+   * Get the url hash of shared GlueBoard
+   */
+  public static get(): SimpleHandler {
+    return async (req, res): Promise<Response> => {
+      const glueBoard = res.locals.glueBoard as GlueBoardDoc
+
+      // if sharing option is off, turn on.
+      if (glueBoard.sharing === false) {
+        glueBoard.sharing = true
+        await glueBoard.save()
+      }
+
+      const responseBody: GetResponseBody = {
+        hash: glueBoard.id
+      }
+
+      return res.status(200).json(responseBody)
+    }
+  }
+}

--- a/src/app/http/controllers/SharingController.ts
+++ b/src/app/http/controllers/SharingController.ts
@@ -1,7 +1,7 @@
 import { Response, SimpleHandler } from '@/http/RequestHandler'
 import { GlueBoardDoc } from '@@/migrate/schemas/glue-board'
 
-interface GetResponseBody {
+interface GetHashResponseBody {
   hash: string
 }
 
@@ -9,7 +9,7 @@ export default class SharingController {
   /**
    * Get the url hash of shared GlueBoard
    */
-  public static get(): SimpleHandler {
+  public static getHash(): SimpleHandler {
     return (req, res): Response => {
       const glueBoard = res.locals.glueBoard as GlueBoardDoc
 
@@ -22,7 +22,7 @@ export default class SharingController {
         })
       }
 
-      const responseBody: GetResponseBody = {
+      const responseBody: GetHashResponseBody = {
         hash: glueBoard.id
       }
 

--- a/src/app/http/middleware/CheckSharing.ts
+++ b/src/app/http/middleware/CheckSharing.ts
@@ -1,0 +1,34 @@
+import { Response, NextHandler } from '@/http/RequestHandler'
+import GlueBoard from '@@/migrate/models/glue-board'
+import { GlueBoardDoc } from '@@/migrate/schemas/glue-board'
+
+export default class CheckSharing {
+  public static handler(): NextHandler {
+    return async (req, res, next): Promise<Response | void> => {
+      const glueBoardID = req.params.glueboard
+      const glueBoard = (await GlueBoard.findOne({
+        id: glueBoardID
+      })) as GlueBoardDoc
+
+      if (!glueBoard) {
+        return res.status(404).json({
+          err: {
+            msg: 'Glueboard not found.'
+          }
+        })
+      }
+
+      if (!glueBoard.sharing) {
+        return res.status(403).json({
+          err: {
+            msg: 'Unshared GlueBoard.'
+          }
+        })
+      }
+
+      res.locals.glueBoard = glueBoard
+
+      return next()
+    }
+  }
+}

--- a/src/app/http/middleware/CheckSharing.ts
+++ b/src/app/http/middleware/CheckSharing.ts
@@ -1,11 +1,24 @@
 import { Response, NextHandler } from '@/http/RequestHandler'
 import GlueBoard from '@@/migrate/models/glue-board'
 import { GlueBoardDoc } from '@@/migrate/schemas/glue-board'
+import { checkSchema, ValidationChain } from 'express-validator'
 
 export default class CheckSharing {
+  public static validate(): ValidationChain[] {
+    return checkSchema({
+      hash: {
+        exists: true,
+        in: 'params',
+        isString: true,
+        trim: true,
+        errorMessage: '`hash` must be a string.'
+      }
+    })
+  }
+
   public static handler(): NextHandler {
     return async (req, res, next): Promise<Response | void> => {
-      const glueBoardID = req.params.glueboard
+      const glueBoardID = req.params.hash
       const glueBoard = (await GlueBoard.findOne({
         id: glueBoardID
       })) as GlueBoardDoc

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -2,12 +2,27 @@ import express from 'express'
 import oauth2Router from '@@/routes/oauth2'
 import meRouter from '@@/routes/me'
 import mirroringRouter from '@@/routes/mirroring'
+import CheckGlueBoard from '@/http/middleware/CheckGlueBoard'
+import RequestValidationError from '@/http/middleware/RequestValidationError'
+import CheckSharing from '@/http/middleware/CheckSharing'
 
 const mainRouter = express.Router()
 
 /**
+ * Middleware
+ */
+
+mainRouter.use(
+  '/sharing/:glueboard',
+  CheckGlueBoard.validate(),
+  RequestValidationError.handler(),
+  CheckSharing.handler()
+)
+
+/**
  * Sub router
  */
+
 mainRouter.use('/oauth2', oauth2Router)
 mainRouter.use('/me', meRouter)
 mainRouter.use('/mirroring', mirroringRouter)

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -5,6 +5,8 @@ import mirroringRouter from '@@/routes/mirroring'
 import CheckGlueBoard from '@/http/middleware/CheckGlueBoard'
 import RequestValidationError from '@/http/middleware/RequestValidationError'
 import CheckSharing from '@/http/middleware/CheckSharing'
+import SharingController from '@/http/controllers/SharingController'
+import Handle405Error from '@/http/middleware/Handle405Error'
 
 const mainRouter = express.Router()
 
@@ -26,5 +28,17 @@ mainRouter.use(
 mainRouter.use('/oauth2', oauth2Router)
 mainRouter.use('/me', meRouter)
 mainRouter.use('/mirroring', mirroringRouter)
+
+/**
+ * Controller
+ */
+
+/**
+ * GET: access to the shared GlueBoard
+ */
+mainRouter
+  .route('/sharing/:glueboard')
+  .get(SharingController.get())
+  .all(Handle405Error.handler())
 
 export default mainRouter

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -2,7 +2,6 @@ import express from 'express'
 import oauth2Router from '@@/routes/oauth2'
 import meRouter from '@@/routes/me'
 import mirroringRouter from '@@/routes/mirroring'
-import CheckGlueBoard from '@/http/middleware/CheckGlueBoard'
 import RequestValidationError from '@/http/middleware/RequestValidationError'
 import CheckSharing from '@/http/middleware/CheckSharing'
 import SharingController from '@/http/controllers/SharingController'
@@ -15,8 +14,8 @@ const mainRouter = express.Router()
  */
 
 mainRouter.use(
-  '/sharing/:glueboard',
-  CheckGlueBoard.validate(),
+  '/sharing/:hash',
+  CheckSharing.validate(),
   RequestValidationError.handler(),
   CheckSharing.handler()
 )
@@ -37,7 +36,7 @@ mainRouter.use('/mirroring', mirroringRouter)
  * GET: access to the shared GlueBoard
  */
 mainRouter
-  .route('/sharing/:glueboard')
+  .route('/sharing/:hash')
   .get(SharingController.get())
   .all(Handle405Error.handler())
 

--- a/src/routes/me.ts
+++ b/src/routes/me.ts
@@ -115,7 +115,7 @@ meRouter
  */
 meRouter
   .route('/glueboards/:glueboard/sharing')
-  .get(SharingController.get())
+  .get(SharingController.getHash())
   .all(Handle405Error.handler())
 
 export default meRouter

--- a/src/routes/me.ts
+++ b/src/routes/me.ts
@@ -7,6 +7,7 @@ import GlueBoardController from '@/http/controllers/GlueBoardController'
 import CheckGlueBoard from '@/http/middleware/CheckGlueBoard'
 import FragmentController from '@/http/controllers/FragmentController'
 import CheckFragment from '@/http/middleware/CheckFragment'
+import SharingController from '@/http/controllers/SharingController'
 
 const meRouter = express.Router({ mergeParams: true })
 
@@ -107,6 +108,14 @@ meRouter
     FragmentController.update()
   )
   .delete(FragmentController.delete())
+  .all(Handle405Error.handler())
+
+/**
+ * GET: get the url hash of shared GlueBoard
+ */
+meRouter
+  .route('/glueboards/:glueboard/sharing')
+  .get(SharingController.get())
   .all(Handle405Error.handler())
 
 export default meRouter


### PR DESCRIPTION
- Add new api endpoint: Get the url hash of shared GlueBoard
- Create new middleware for check sharing
- Add new api endpoint: Access to the shared GlueBoard